### PR TITLE
change the way to requiring sfl in gemspec to avoid warning

### DIFF
--- a/sfl.gemspec
+++ b/sfl.gemspec
@@ -1,4 +1,8 @@
-require File.expand_path('../lib/sfl', __FILE__)
+libdir = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift libdir unless $LOAD_PATH.include? libdir
+
+require 'sfl'
+
 Gem::Specification.new do |s|
   s.name = %q{sfl}
   s.version = SFL::VERSION.dup


### PR DESCRIPTION
The current `sfl.gemspec` file requires `sfl``by specifying its full path.
Because of it, these warnings are displayed when``sfl`` is required under bundler.

```
/Users/kenta-murata/.rvm/gems/ree-1.8.7-2012.01/bundler/gems/spawn-for-legacy-4a18d8e05072/lib/sfl.rb:2: warning: already initialized constant VERSION
/Users/kenta-murata/.rvm/gems/ree-1.8.7-2012.01/bundler/gems/spawn-for-legacy-4a18d8e05072/lib/sfl.rb:4: warning: already initialized constant SHELL_SPECIALS
/Users/kenta-murata/.rvm/gems/ree-1.8.7-2012.01/bundler/gems/spawn-for-legacy-4a18d8e05072/lib/sfl.rb:78: warning: already initialized constant REDIRECTION_MAPPING
```

To avoid these warnings, I fixed `sfl.gemspec` to add the path of `lib` dir of sfl into `$LOAD_PATH` before requiring `sfl`.
